### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Create release
+
+# Taken from https://github.com/haya14busa/action-bumpr/blob/master/.github/workflows/release.yml
+#
+# And adapted to use https://github.com/softprops/action-gh-release
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "v*.*.*"
+  pull_request:
+    types:
+      - labeled
+
+jobs:
+  release:
+    if: github.event.action != 'labeled'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      # Bumpr bumps version when pr is labeled
+      - id: bumpr
+        if: "!startsWith(github.ref, 'refs/tags/')"
+        uses: haya14busa/action-bumpr@v1
+
+      # Update appropriate minor and major tags
+      - uses: haya14busa/action-update-semver@v1
+        if: "!steps.bumpr.outputs.skip"
+        with:
+          tag: ${{ steps.bumpr.outputs.next_version }}
+
+      # Get tag name.
+      - id: tag
+        uses: haya14busa/action-cond@v1
+        with:
+          cond: "${{ startsWith(github.ref, 'refs/tags/') }}"
+          if_true: ${{ github.ref }}
+          if_false: ${{ steps.bumpr.outputs.next_version }}
+
+      # Create gh release
+      - name: Release
+        if: "steps.tag.outputs.value != ''"
+        uses: softprops/action-gh-release@v1
+        with:
+          body: ${{ steps.bumpr.outputs.message }}
+          tag_name: ${{ steps.tag.outputs.value }}
+          name: Release ${{ steps.tag.outputs.value }}
+
+  release-check:
+    if: github.event.action == 'labeled'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: haya14busa/action-bumpr
+        uses: haya14busa/action-bumpr@v1


### PR DESCRIPTION
This creates a new tag when a 'bump' label is specified for an issue
and updates existing ones according to SemVer. It also creates a new github release.

This closes #16. 